### PR TITLE
docs(readme): fix typo [no ci]

### DIFF
--- a/internal/server/_client/README.md
+++ b/internal/server/_client/README.md
@@ -3,7 +3,7 @@
 Local Development
 ---
 
-Prequisites
+Prerequisites
 
 - gleam
 


### PR DESCRIPTION
Found via `typos --hidden --format brief`