### PR TITLE
set up proper .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-*.js linguist-vendored
-*.mjs linguist-vendored
-*.css linguist-vendored
-*.html linguist-vendored
+* linguist-detectable=false
+*.go linguist-detectable=true
+*.gleam linguist-detectable=true


### PR DESCRIPTION
## Summary
- set up proper .gitattributes to keep GitHub language stats focused on primary project language(s).